### PR TITLE
Update container to run GRIDSS 2.5.1

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,14 +3,19 @@
 FROM ubuntu:18.04
 
 ################## METADATA ######################
+
+ENV GRIDSS_VERSION 2.5.1
+ENV SAMBAMBA_VERSION 0.7.0
+
+ENV GRIDSS_JAR "/opt/gridss/gridss-${GRIDSS_VERSION}-gridss-jar-with-dependencies.jar"
+
 LABEL base.image="ubuntu:18.04"
 LABEL version="1"
 LABEL software="GRIDSS"
-LABEL software.version="2.5.0"
+LABEL software.version="${GRIDSS_VERSION}"
 LABEL about.summary="Genomic Rearrangement IDentification Software Suite"
 LABEL about.home="https://github.com/PapenfussLab/gridss"
 LABEL about.tags="Genomics"
-
 
 RUN bash -c 'echo -e "deb http://archive.ubuntu.com/ubuntu/ xenial main restricted universe multiverse\n\
 deb http://archive.ubuntu.com/ubuntu/ xenial-updates main restricted universe multiverse\n\
@@ -23,17 +28,38 @@ RUN apt-get install -y r-base
 RUN apt-get install -y bwa
 RUN apt-get install -y time
 
-RUN useradd -ms /bin/bash gridss
-RUN mkdir /data
-RUN chown gridss /data
-RUN chgrp users /data
-RUN chmod 777 /data
+RUN useradd -Ms /bin/bash gridss
 
-RUN mkdir /data/gridss
-ADD https://github.com/PapenfussLab/gridss/releases/download/v2.5.0/gridss-2.5.0-gridss-jar-with-dependencies.jar /data/gridss/
-ADD https://github.com/PapenfussLab/gridss/releases/download/v2.5.0/gridss.sh /data/gridss/
-ADD https://github.com/PapenfussLab/gridss/releases/download/v2.5.0/gridss_lite.sh /data/gridss/
-RUN chmod +x  /data/gridss/gridss*.sh
-WORKDIR /data/gridss/
+# Install sambamba
+RUN mkdir -p /opt/sambamba
+ADD https://github.com/biod/sambamba/releases/download/v${SAMBAMBA_VERSION}/sambamba-${SAMBAMBA_VERSION}-linux-static.gz /opt/sambamba/
 
-ENTRYPOINT ["/data/gridss/gridss.sh", "--jar", "/data/gridss/gridss-2.5.0-gridss-jar-with-dependencies.jar"]
+RUN cd /opt/sambamba \
+    && gunzip sambamba-${SAMBAMBA_VERSION}-linux-static.gz \
+    && mv sambamba-${SAMBAMBA_VERSION}-linux-static sambamba \
+    && chmod +x sambamba
+
+# Install gridss to /opt/gridss, and hard link it from /data/ to maintain backwards compatability
+RUN mkdir -p /opt/gridss
+ADD https://github.com/PapenfussLab/gridss/releases/download/v${GRIDSS_VERSION}/gridss-${GRIDSS_VERSION}-gridss-jar-with-dependencies.jar ${GRIDSS_JAR}
+ADD https://github.com/PapenfussLab/gridss/releases/download/v${GRIDSS_VERSION}/gridss.sh /opt/gridss/
+# ADD https://github.com/PapenfussLab/gridss/releases/download/v${GRIDSS_VERSION}/gridss_lite.sh /opt/gridss/
+
+RUN chmod +x  /opt/gridss/gridss*.sh
+
+RUN chown -R gridss /opt
+RUN chgrp users /opt
+RUN chmod -Rv 755 /opt/gridss/
+
+RUN mkdir -p /data/gridss
+RUN ln /opt/gridss/gridss-${GRIDSS_VERSION}-gridss-jar-with-dependencies.jar /data/gridss/gridss-${GRIDSS_VERSION}-gridss-jar-with-dependencies.jar
+RUN ln /opt/gridss/gridss.sh /data/gridss/gridss.sh
+# RUN ln /opt/gridss/gridss-lite.sh /data/gridss/gridss-lite.sh
+
+# RUN chmod -R 777 /data
+
+WORKDIR /opt/gridss/
+ENV PATH="/opt/gridss:/opt/sambamba:${PATH}"
+
+# See https://stackoverflow.com/a/37904830/2860731 for "echo $GRIDSS_JAR" explanation
+ENTRYPOINT ["/opt/gridss/gridss.sh"]

--- a/example/gridss.sh
+++ b/example/gridss.sh
@@ -16,7 +16,7 @@ Usage: gridss.sh --reference <reference.fa> --output <output.vcf.gz> --assembly 
 	-o/--output: output VCF.
 	-a/--assembly: location of the GRIDSS assembly BAM. This file will be created by GRIDSS.
 	-t/--threads: number of threads to use. Defaults to the number of cores available.
-	-j/--jar: location of GRIDSS jar
+	-j/--jar: location of GRIDSS jar (defaults to $GRIDSS_JAR)
 	-w/--workingdir: directory to place GRIDSS intermediate and temporary files. .gridss.working subdirectories will be created. Defaults to the current directory.
 	-b/--blacklist: BED file containing regions to ignore
 	-s/--steps: processing steps to run. Defaults to all steps. Multiple steps are specified using comma separators
@@ -42,7 +42,7 @@ reference=""
 output_vcf=""
 assembly=""
 threads=$(nproc)
-gridss_jar=""
+gridss_jar="$GRIDSS_JAR"
 jvmheap="25g"
 blacklist=""
 metricsrecords=10000000
@@ -138,7 +138,7 @@ if [[ "$gridss_jar" == "" ]] ; then
 fi
 if [[ ! -f $gridss_jar ]] ; then
 	echo "$USAGE_MESSAGE"  1>&2
-	echo "Unable to find GRIDSS jar. Specify location using the --jar command line argument" 1>&2
+	echo "Unable to find GRIDSS jar (at $gridss_jar). Specify location using the --jar command line argument" 1>&2
 	exit 2
 fi
 ##### --workingdir


### PR DESCRIPTION
This is still a WIP, but wanted to create this PR to modify the official docker container to run more smoothly on Singularity and through workflow engines.

Main changes:
- Install GRIDSS to `/opt` (link back to data)
- Include ENV (`GRIDSS_JARFILE`) variable to jarfile location
- Allow `gridss.sh` to default to this new env variable
- Include Sambamba in container (currently latest == 0.7.0)
- Add `/opt/gridss` and `/opt/sambamba` to path.
- Removed the `--jar longpathtogridss.jar` from the entrypoint.

I've got this container hosted on Dockerhub as: [`michaelfranklin/gridss:2.5.1-dev2`](https://hub.docker.com/r/michaelfranklin/gridss/tags) so you could test it. I'm still doing a bit more testing, but wanted to collect some early feedback.