### PR TITLE
Replace sambamba with samtools for better stability outside Docker

### DIFF
--- a/scripts/gridss.sh
+++ b/scripts/gridss.sh
@@ -299,7 +299,7 @@ if [[ "$labels" != "" ]] ; then
 fi
 
 # Validate tools exist on path
-for tool in bwa Rscript /usr/bin/time sambamba java ; do
+for tool in bwa Rscript /usr/bin/time samtools java ; do
 	if ! which $tool >/dev/null; then echo "Error: unable to find $tool on \$PATH" 1>&2 ; exit 2; fi
 	echo "Found $(which $tool)" 1>&2 
 done
@@ -373,7 +373,7 @@ if [[ $do_preprocess == true ]] ; then
 				STOP_AFTER=$metricsrecords \
 				$picardoptions \
 			; } 1>&2 2>> $logfile
-			echo "$(date)	CollectGridssMetricsAndExtractSVReads|sambamba	$f" | tee -a $timinglogfile
+			echo "$(date)	CollectGridssMetricsAndExtractSVReads|samtools	$f" | tee -a $timinglogfile
 			{ /usr/bin/time -a -o $timinglogfile \
 				java -Xmx4g $jvm_args \
 					-cp $gridss_jar gridss.CollectGridssMetricsAndExtractSVReads \
@@ -400,16 +400,17 @@ if [[ $do_preprocess == true ]] ; then
 					INCLUDE_DUPLICATES=true \
 					$picardoptions \
 			| /usr/bin/time -a -o $timinglogfile \
-				sambamba sort \
+				samtools sort \
 					-n \
-					--tmpdir $dir \
+					-T $tmp_prefix.namedsorted-tmp \
 					-m 8GB \
+					-Obam \
 					-o $tmp_prefix.namedsorted.bam \
-					-t $threads \
+					-@ $threads \
 					/dev/stdin \
 			; } 1>&2 2>> $logfile
 			rm $tmp_prefix.insert_size_metrics $tmp_prefix.insert_size_histogram.pdf
-			echo "$(date)	ComputeSamTags|sambamba	$f" | tee -a $timinglogfile
+			echo "$(date)	ComputeSamTags|samtools	$f" | tee -a $timinglogfile
 			{ /usr/bin/time -a -o $timinglogfile \
 				java -Xmx4g $jvm_args \
 					-cp $gridss_jar gridss.ComputeSamTags \
@@ -433,11 +434,12 @@ if [[ $do_preprocess == true ]] ; then
 					ASSUME_SORTED=true \
 					$picardoptions \
 			| /usr/bin/time -a -o $timinglogfile \
-				sambamba sort \
-					--tmpdir $dir \
+				samtools sort \
+					-T $tmp_prefix.coordinate-tmp \
 					-m 8GB \
+					-Obam \
 					-o $tmp_prefix.coordinate.bam \
-					-t $threads \
+					-@ $threads \
 					/dev/stdin \
 			; } 1>&2 2>> $logfile
 			rm $tmp_prefix.namedsorted.bam
@@ -455,22 +457,25 @@ if [[ $do_preprocess == true ]] ; then
 					OUTPUT_UNORDERED_RECORDS=$tmp_prefix.sc2sr.supp.sv.bam \
 					WORKER_THREADS=$threads \
 					$picardoptions \
-			&& rm $tmp_prefix.coordinate.bam $tmp_prefix.coordinate.bam.bai \
+			&& rm $tmp_prefix.coordinate.bam \
 			&& /usr/bin/time -a -o $timinglogfile \
-				sambamba sort \
-					-t $threads \
-					--tmpdir $dir \
+				samtools sort \
+					-@ $threads \
+					-T $tmp_prefix.sc2sr.suppsorted.sv-tmp \
+					-Obam \
 					-o $tmp_prefix.sc2sr.suppsorted.sv.bam \
 					$tmp_prefix.sc2sr.supp.sv.bam \
 			&& rm $tmp_prefix.sc2sr.supp.sv.bam \
 			&& /usr/bin/time -a -o $timinglogfile \
-				sambamba merge \
-					-t $threads \
+				samtools merge \
+					-@ $threads \
 					$prefix.sv.tmp.bam \
 					$tmp_prefix.sc2sr.primary.sv.bam \
 					$tmp_prefix.sc2sr.suppsorted.sv.bam \
+			&& /usr/bin/time -a -o $timinglogfile \
+				samtools index $prefix.sv.tmp.bam \
 			&& rm $tmp_prefix.sc2sr.primary.sv.bam \
-			&& rm $tmp_prefix.sc2sr.suppsorted.sv.bam $tmp_prefix.sc2sr.suppsorted.sv.bam.bai \
+			&& rm $tmp_prefix.sc2sr.suppsorted.sv.bam \
 			&& mv $prefix.sv.tmp.bam $prefix.sv.bam \
 			&& mv $prefix.sv.tmp.bam.bai $prefix.sv.bam.bai \
 			; } 1>&2 2>> $logfile
@@ -551,20 +556,23 @@ if [[ $do_assemble == true ]] ; then
 				REALIGN_ENTIRE_READ=true \
 				$picardoptions \
 		&& /usr/bin/time -a -o $timinglogfile \
-			sambamba sort \
-				-t $threads \
-				--tmpdir $dir \
+			samtools sort \
+				-@ $threads \
+				-T $tmp_prefix.sc2sr.suppsorted.sv-tmp \
+				-Obam \
 				-o $tmp_prefix.sc2sr.suppsorted.sv.bam \
 				$tmp_prefix.sc2sr.supp.sv.bam \
 		&& rm $tmp_prefix.sc2sr.supp.sv.bam \
 		&& /usr/bin/time -a -o $timinglogfile \
-			sambamba merge \
-				-t $threads \
+			samtools merge \
+				-@ $threads \
 				$prefix.sv.tmp.bam \
 				$tmp_prefix.sc2sr.primary.sv.bam \
 				$tmp_prefix.sc2sr.suppsorted.sv.bam \
+		&& /usr/bin/time -a -o $timinglogfile \
+			samtools index $prefix.sv.tmp.bam \
 		&& rm $tmp_prefix.sc2sr.primary.sv.bam \
-		&& rm $tmp_prefix.sc2sr.suppsorted.sv.bam $tmp_prefix.sc2sr.suppsorted.sv.bam.bai \
+		&& rm $tmp_prefix.sc2sr.suppsorted.sv.bam \
 		&& mv $prefix.sv.tmp.bam $prefix.sv.bam \
 		&& mv $prefix.sv.tmp.bam.bai $prefix.sv.bam.bai \
 		; } 1>&2 2>> $logfile


### PR DESCRIPTION
Hi Daniel,

What do you think about replacing sambamba with samtools calls? Sambamba is known to sometimes die with sigfaults on certain machines when ran in multiple threads, so this change will make GRIDSS more stable when used on HPC that don't have Docker (which is so common these days unfortunately; in particular, I couldn't make GRIDSS reliably work on [NCI](https://opus.nci.org.au/display/Help/Raijin+User+Guide)).

Sambamba issues used to cause pain in bcbio, until [Brad replaced it with samtools calls](https://github.com/bcbio/bcbio-nextgen/commit/db92a7b3278c638f44b51940e342de67d656ee6b#diff-a0e1d2fd0fd7dc401277f79acfc4d02d) (luckily, samtools became multi-threaded in 2017). So perhaps this change might be helpful for GRIDSS as well. I tested the change on my side on NCI, the pipeline finishes properly.

Vlad