### PR TITLE
Sets READ_PAIR_CONCORDANT_PERCENT to $readpairpdistribution

### DIFF
--- a/scripts/gridss.sh
+++ b/scripts/gridss.sh
@@ -515,11 +515,10 @@ aligner_args_minimap2='
 	--ALIGNER_COMMAND_LINE %1$s
 	'
 
-readpairing_args=""
-
-READ_PAIR_CONCORDANT_PERCENT="$readpairpdistribution"
 if [[ "$useproperpair" == "true" ]] ; then
 	readpairing_args="READ_PAIR_CONCORDANT_PERCENT=null"
+else
+  readpairing_args="READ_PAIR_CONCORDANT_PERCENT=${readpairpdistribution}"
 fi
 
 if [[ $do_setupreference == true ]] ; then


### PR DESCRIPTION
Previously, readpairing_args is set to `"READ_PAIR_CONCORDANT_PERCENT=null"` if `--useproperpair` is set, otherwise  set to `""`.   

Fixes https://github.com/PapenfussLab/gridss/issues/444