### PR TITLE
improve logging message when vcf already exists

### DIFF
--- a/scripts/gridss
+++ b/scripts/gridss
@@ -1196,7 +1196,7 @@ if [[ $do_call == true ]] ; then
 		&& $rmcmd $prefix.allocated.vcf \
 		; } 1>&2 2>> $logfile
 	else
-		write_status  "Skipping variant calling	$output_vcf"
+		write_status  "Skipping variant calling	as $output_vcf already exists."
 	fi
 	write_status "Complete calling	$output_vcf"
 else


### PR DESCRIPTION
Hi. I was a bit puzzled why GRIDSS didn't perform calling. My workflow manager pre-created empty output files, which seems to be incompatible with GRIDSS. The log message should now state the reason explicitly.