### PR TITLE
Fix typo in VIRUSBreakend_Readme.md

### DIFF
--- a/VIRUSBreakend_Readme.md
+++ b/VIRUSBreakend_Readme.md
@@ -53,7 +53,7 @@ The reference file database contains the following files:
 |library/added/\*.fna|NCBI viral neighbour genomes|
 |\*.fai|samtools index of associated .fna file|
 |\*.fna.dict|Picard tools sequence dictionary  of associated .fna file|
-|opts.k2d|Kraken2 database file|
+|hash.k2d|Kraken2 database file|
 |taxo.k2d|Kraken2 database file|
 |opts.k2d|Kraken2 database file|
 |taxonomy/nodes.dmp|Snapshot of NCBI taxonomy nodes at time of database creation|


### PR DESCRIPTION
There is a duplicate opts.k2d. I think one is hash.k2d.

![image](https://user-images.githubusercontent.com/5798442/171368878-ca64e012-698c-4378-80e9-43c3f858de10.png)
