### PR TITLE
Use JUnit assumption in SswJniAlignerTest

### DIFF
--- a/src/test/java/au/edu/wehi/idsv/alignment/SswJniAlignerTest.java
+++ b/src/test/java/au/edu/wehi/idsv/alignment/SswJniAlignerTest.java
@@ -1,11 +1,11 @@
 package au.edu.wehi.idsv.alignment;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
 
 public class SswJniAlignerTest extends SmithWatermanAlignerTest {
     @Override
     protected Aligner create(int match, int mismatch, int ambiguous, int gapOpen, int gapExtend) {
-        assertTrue(AlignerFactory.isSswjniLoaded());
+        assumeTrue(AlignerFactory.isSswjniLoaded());
         return new SswJniAligner(match, mismatch, ambiguous, gapOpen, gapExtend);
     }
 }


### PR DESCRIPTION
It should be ignored on non-x86_64 systems until src/main/resources/libsswjni.so is provided for other architectures.

Related-to: #592