### PR TITLE
Fix constant name in gridsstools.c

### DIFF
--- a/docker/Readme.md
+++ b/docker/Readme.md
@@ -3,7 +3,7 @@
 
 ## Summary
 
-GRIDSS analyses multiple bams from a single patient simulataneously, thus
+GRIDSS analyses multiple bams from a single patient simultaneously, thus
 achieving high sensitivity and consistency between samples. This software
 package provides docker images and helper scripts to easily run GRIDSS on bam files from a
 cohort of patients with one or more samples per patient.

--- a/src/main/c/gridsstools/gridsstools.c
+++ b/src/main/c/gridsstools/gridsstools.c
@@ -28,7 +28,7 @@ int main(int argc, char *argv[]) {
 	else if (strcmp(argv[1], "extractFragmentsToBam") == 0) return main_extractFragmentsToBam(argc-1, argv+1);
 	else if (strcmp(argv[1], "unmappedSequencesToFastq") == 0) return main_unmappedSequencesToFastq(argc-1, argv+1);
 	else if (strcmp(argv[1], "-v") == 0 || strcmp(argv[1], "--version") == 0) {
-		fprintf(stdout, "%s\n", PACKAGE_STRING);
+		fprintf(stdout, "%s\n", PACKAGE_VERSION);
 		return 0;
 	} else {
 		fprintf(stderr, "[main] unrecognized command '%s'\n", argv[1]);


### PR DESCRIPTION
Introduced-with: https://github.com/PapenfussLab/gridss/commit/f697add7e4e77c750040956b844c3a81a8c56ff4#diff-6527a035f98fd22ebbce50692b6118224f41eccf71dd59f4ea388b7aba02f356

Fix a typo in a README file